### PR TITLE
Revert "op3(t): overlay: enable config_fingerprintRemoveClientOnCancel"

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -418,8 +418,6 @@
         <item>"/system/framework/arm64/boot-core-libart.oat"</item>
    </string-array>
 
-   <bool name="config_fingerprintRemoveClientOnCancel">true</bool>
-
     <!-- Whether device has dash charging support -->
     <bool name="config_hasDashCharger">true</bool>
 


### PR DESCRIPTION
This reverts commit 47dad433b9e9976fa69e1ccb3a0b5595c75deb0c.