### PR TITLE
op3: Doze: Require non-wake up proximity sensor

### DIFF
--- a/doze/src/com/cyanogenmod/settings/doze/ProximitySensor.java
+++ b/doze/src/com/cyanogenmod/settings/doze/ProximitySensor.java
@@ -45,7 +45,7 @@ public class ProximitySensor implements SensorEventListener {
     public ProximitySensor(Context context) {
         mContext = context;
         mSensorManager = (SensorManager) mContext.getSystemService(Context.SENSOR_SERVICE);
-        mSensor = mSensorManager.getDefaultSensor(Sensor.TYPE_PROXIMITY);
+        mSensor = mSensorManager.getDefaultSensor(Sensor.TYPE_PROXIMITY, false);
     }
 
     @Override


### PR DESCRIPTION
* getDefaultSensor(type) returns the first sensor
  and in case of capricorn it's wake-up one thus our
  doze package wouldn't work. Passing `false` as a second
  argument makes it work properly.

Change-Id: If73bc43bc166945d27b95513c4255ae5a5590849